### PR TITLE
Various updates

### DIFF
--- a/circuits/withdraw.circom
+++ b/circuits/withdraw.circom
@@ -8,7 +8,6 @@ template Withdraw(levels) {
     signal input recipient; // not taking part in any computations
     signal input relayer;  // not taking part in any computations
     signal input fee;      // not taking part in any computations
-    signal input refund;   // not taking part in any computations
     signal private input nullifier;
     signal private input pathElements[levels];
     signal private input pathIndices[levels];
@@ -42,11 +41,9 @@ template Withdraw(levels) {
     signal recipientSquare;
     signal feeSquare;
     signal relayerSquare;
-    signal refundSquare;
     recipientSquare <== recipient * recipient;
     feeSquare <== fee * fee;
     relayerSquare <== relayer * relayer;
-    refundSquare <== refund * refund;
 }
 
 component main = Withdraw(20);

--- a/contracts/ETHTornado.sol
+++ b/contracts/ETHTornado.sol
@@ -23,17 +23,12 @@ contract ETHTornado is Tornado {
     function _processWithdraw(
         address payable _recipient,
         address payable _relayer,
-        uint256 _fee,
-        uint256 _refund
+        uint256 _fee
     ) internal override {
         // sanity checks
         require(
             msg.value == 0,
             "Message value is supposed to be zero for ETH instance"
-        );
-        require(
-            _refund == 0,
-            "Refund value is supposed to be zero for ETH instance"
         );
 
         (bool success, ) = _recipient.call{ value: (denomination - _fee) }("");

--- a/contracts/Tornado.sol
+++ b/contracts/Tornado.sol
@@ -17,7 +17,7 @@ interface IVerifier {
         uint256[2] calldata a,
         uint256[2][2] calldata b,
         uint256[2] calldata c,
-        uint256[6] calldata input
+        uint256[5] calldata input
     ) external view returns (bool);
 }
 
@@ -83,8 +83,7 @@ abstract contract Tornado is MerkleTreeWithHistory, ReentrancyGuard {
         bytes32 _nullifierHash,
         address payable _recipient,
         address payable _relayer,
-        uint256 _fee,
-        uint256 _refund
+        uint256 _fee
     ) external payable nonReentrant {
         require(_fee <= denomination, "Fee exceeds transfer value");
         require(
@@ -102,15 +101,14 @@ abstract contract Tornado is MerkleTreeWithHistory, ReentrancyGuard {
                     uint256(_nullifierHash),
                     uint256(_recipient),
                     uint256(_relayer),
-                    _fee,
-                    _refund
+                    _fee
                 ]
             ),
             "Invalid withdraw proof"
         );
 
         nullifierHashes[_nullifierHash] = true;
-        _processWithdraw(_recipient, _relayer, _fee, _refund);
+        _processWithdraw(_recipient, _relayer, _fee);
         emit Withdrawal(_recipient, _nullifierHash, _relayer, _fee);
     }
 
@@ -118,8 +116,7 @@ abstract contract Tornado is MerkleTreeWithHistory, ReentrancyGuard {
     function _processWithdraw(
         address payable _recipient,
         address payable _relayer,
-        uint256 _fee,
-        uint256 _refund
+        uint256 _fee
     ) internal virtual;
 
     function isSpent(bytes32 _nullifierHash) public view returns (bool) {

--- a/quickSetup.sh
+++ b/quickSetup.sh
@@ -1,14 +1,24 @@
 # Use existing public phase 1 setup
-curl -o build/phase1_final.ptau https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_14.ptau
+PHASE1=build/phase1_final.ptau
+PHASE2=build/phase2_final.ptau
+CIRCUIT_ZKEY=build/circuit_final.zkey
+
+# Phase 1
+if [ -f "$PHASE1" ]; then
+    echo "Phase 1 file exists, no action"
+else
+    echo "Phase 1 file does not exist, downloading ..."
+    curl -o $PHASE1 https://hermez.s3-eu-west-1.amazonaws.com/powersOfTau28_hez_final_14.ptau
+fi
 
 # Untrusted phase 2
-npx snarkjs powersoftau prepare phase2 build/phase1_final.ptau build/phase2_final.ptau -v
+npx snarkjs powersoftau prepare phase2 $PHASE1 $PHASE2 -v
 
-npx snarkjs zkey new build/withdraw.r1cs build/phase2_final.ptau build/circuit_final.zkey
+npx snarkjs zkey new build/withdraw.r1cs $PHASE2 $CIRCUIT_ZKEY
 
-npx snarkjs zkey export verificationkey build/circuit_final.zkey build/verification_key.json
+npx snarkjs zkey export verificationkey $CIRCUIT_ZKEY build/verification_key.json
 
 
-npx snarkjs zkey export solidityverifier build/circuit_final.zkey build/Verifier.sol
+npx snarkjs zkey export solidityverifier $CIRCUIT_ZKEY build/Verifier.sol
 # Fix solidity version (and want the command to work on both linux and mac)
 cd build/ && sed 's/0\.6\.11/0\.7\.3/g' Verifier.sol > tmp.txt && mv tmp.txt Verifier.sol

--- a/tests/ETHTornado.test.ts
+++ b/tests/ETHTornado.test.ts
@@ -113,7 +113,6 @@ describe("ETHTornado", function () {
         const recipient = await userNewSigner.getAddress();
         const relayer = await relayerSigner.getAddress();
         const fee = 0;
-        const refund = 0;
 
         const { root, path_elements, path_index } = await tree.path(
             deposit.leafIndex
@@ -126,7 +125,6 @@ describe("ETHTornado", function () {
             recipient,
             relayer,
             fee,
-            refund,
             // Private
             nullifier: BigNumber.from(deposit.nullifier).toBigInt(),
             pathElements: path_elements,
@@ -141,15 +139,7 @@ describe("ETHTornado", function () {
 
         const txWithdraw = await tornado
             .connect(relayerSigner)
-            .withdraw(
-                solProof,
-                root,
-                nullifierHash,
-                recipient,
-                relayer,
-                fee,
-                refund
-            );
+            .withdraw(solProof, root, nullifierHash, recipient, relayer, fee);
         const receiptWithdraw = await txWithdraw.wait();
         console.log("Withdraw gas cost", receiptWithdraw.gasUsed.toNumber());
     }).timeout(500000);
@@ -175,7 +165,6 @@ describe("ETHTornado", function () {
         const recipient = await userNewSigner.getAddress();
         const relayer = await relayerSigner.getAddress();
         const fee = 0;
-        const refund = 0;
 
         const { root, path_elements, path_index } = await tree.path(
             deposit.leafIndex
@@ -188,7 +177,6 @@ describe("ETHTornado", function () {
             recipient,
             relayer,
             fee,
-            refund,
             // Private
             nullifier: BigNumber.from(deposit.nullifier).toBigInt(),
             pathElements: path_elements,
@@ -204,28 +192,12 @@ describe("ETHTornado", function () {
         // First withdraw
         await tornado
             .connect(relayerSigner)
-            .withdraw(
-                solProof,
-                root,
-                nullifierHash,
-                recipient,
-                relayer,
-                fee,
-                refund
-            );
+            .withdraw(solProof, root, nullifierHash, recipient, relayer, fee);
 
         // Second withdraw
         await tornado
             .connect(relayerSigner)
-            .withdraw(
-                solProof,
-                root,
-                nullifierHash,
-                recipient,
-                relayer,
-                fee,
-                refund
-            )
+            .withdraw(solProof, root, nullifierHash, recipient, relayer, fee)
             .then(
                 () => {
                     assert.fail("Expect tx to fail");


### PR DESCRIPTION
- Fix #5, added tests for double withdraw and non-existent root
- remove refund. refund is used in the ERC20 case. Removing it so that non-ERC case is simpler
- abstract the groth16 proof parsing, which is a part too tedious to explicitly leave in the tests.
- improve the setup script so that we don't have to comment out the download part every time when redoing the circuit.